### PR TITLE
T3.5 and T3.6 fixes

### DIFF
--- a/ADC.cpp
+++ b/ADC.cpp
@@ -147,9 +147,9 @@ const uint8_t ADC::sc1a2channelADC0[]= { // new version, gives directly the pin 
 };
 #elif defined(ADC_TEENSY_3_5) || defined(ADC_TEENSY_3_6)
 const uint8_t ADC::sc1a2channelADC0[]= { // new version, gives directly the pin number
-    34, 0, 0, 36, 23, 14, 20, 21, 16, 17, 0, 0, 19, 18, // 0-13
-    15, 22, 23, 0, 0, 35, 0, 37, // 14-21
-    39, 40, 0, 0, 38, 41, 42, 43, // VREF_OUT, A14, temp. sensor, bandgap, VREFH, VREFL.
+    0, 68, 0, 64, 23, 14, 20, 21, 16, 17, 0, 0, 19, 18, // 0-13
+    15, 22, 0, 33, 34, 0, 0, 0, // 14-21
+    0, 66, 0, 0, 70, 0, 0, 0, // 22-29
     0 // 31 means disabled, but just in case
 };
 #endif // defined
@@ -164,10 +164,10 @@ const uint8_t ADC::sc1a2channelADC1[]= { // new version, gives directly the pin 
 };
 #elif defined(ADC_TEENSY_3_5) || defined(ADC_TEENSY_3_6)
 const uint8_t ADC::sc1a2channelADC1[]= { // new version, gives directly the pin number
-    36, 0, 0, 34, 28, 26, 29, 30, 16, 17, 0, 0, 0, 0, // 0-13. 5a=26, 5b=27, 4b=28, 4a=31
-    0, 0, 0, 0, 39, 37, 0, 0, // 14-21
-    0, 0, 0, 0, 38, 41, 0, 42, // 22-29. VREF_OUT, A14, temp. sensor, bandgap, VREFH, VREFL.
-    43
+    0, 69, 0, 0, 35, 36, 37, 38, 0, 0, 49, 50, 0, 0, // 0-13.
+    31, 32, 0, 39, 71, 65, 0, 0, // 14-21
+    0, 67, 0, 0, 0, 0, 0, 0, // 22-29.
+    0
 };
 #endif
 

--- a/ADC_Module.cpp
+++ b/ADC_Module.cpp
@@ -73,7 +73,11 @@ ADC_Module::ADC_Module(uint8_t ADC_number, const uint8_t* const a_channel2sc1a, 
         , ADC_CLM1(&ADC0_CLM1 + adc_offset*ADC_num)
         , ADC_CLM0(&ADC0_CLM0 + adc_offset*ADC_num)
         , PDB0_CHnC1(&PDB0_CH0C1 + ADC_num*0xA)
+#if ADC_NUM_ADCS==2
+        , IRQ_ADC(ADC_num? IRQ_ADC1 : IRQ_ADC0) // fix by SB (Teensy 3.6)
+#else
         , IRQ_ADC(IRQ_ADC0 + ADC_num*1)
+#endif
         {
 
 


### PR DESCRIPTION
The tables to convert from a channel to pin number, which was used in at least one of the example sketches, was not updated for the Teensy 3.5 and 3.6.  Earlier their tables were simply duplicated.   I went through the tables that convert a pin number to a channel and built the tables.

Also the enable interrupts for IRQ_ADC1 did not work on the new chips.  The problem is the code assumes that IRQ_ADC0 and IRQ_ADC1 are right after each other, which on T3.2 works (57, 58),
But on T3.6 they are 39 and 73...