### PR TITLE
zero initialization using {} instead of {0}

### DIFF
--- a/ADC.cpp
+++ b/ADC.cpp
@@ -959,7 +959,7 @@ ADC::Sync_result ADC::analogSynchronizedRead(uint8_t pin0, uint8_t pin1) {
 
     // check if we are interrupting a measurement, store setting if so.
     // vars to save the current state of the ADC in case it's in use
-    ADC_Module::ADC_Config old_adc0_config = {0};
+    ADC_Module::ADC_Config old_adc0_config = {};
     uint8_t wasADC0InUse = adc0->isConverting(); // is the ADC running now?
     if(wasADC0InUse) { // this means we're interrupting a conversion
         // save the current conversion config, the adc isr will restore the adc
@@ -968,7 +968,7 @@ ADC::Sync_result ADC::analogSynchronizedRead(uint8_t pin0, uint8_t pin1) {
         adc0->saveConfig(&old_adc0_config);
         __enable_irq();
     }
-    ADC_Module::ADC_Config old_adc1_config = {0};
+    ADC_Module::ADC_Config old_adc1_config = {};
     uint8_t wasADC1InUse = adc1->isConverting(); // is the ADC running now?
     if(wasADC1InUse) { // this means we're interrupting a conversion
         // save the current conversion config, the adc isr will restore the adc
@@ -1046,7 +1046,7 @@ ADC::Sync_result ADC::analogSynchronizedReadDifferential(uint8_t pin0P, uint8_t 
 
     // check if we are interrupting a measurement, store setting if so.
     // vars to save the current state of the ADC in case it's in use
-    ADC_Module::ADC_Config old_adc0_config = {0};
+    ADC_Module::ADC_Config old_adc0_config = {};
     uint8_t wasADC0InUse = adc0->isConverting(); // is the ADC running now?
     if(wasADC0InUse) { // this means we're interrupting a conversion
         // save the current conversion config, the adc isr will restore the adc
@@ -1055,7 +1055,7 @@ ADC::Sync_result ADC::analogSynchronizedReadDifferential(uint8_t pin0P, uint8_t 
         adc0->saveConfig(&old_adc0_config);
         __enable_irq();
     }
-    ADC_Module::ADC_Config old_adc1_config = {0};
+    ADC_Module::ADC_Config old_adc1_config = {};
     uint8_t wasADC1InUse = adc1->isConverting(); // is the ADC running now?
     if(wasADC1InUse) { // this means we're interrupting a conversion
         // save the current conversion config, the adc isr will restore the adc

--- a/ADC_Module.cpp
+++ b/ADC_Module.cpp
@@ -838,7 +838,7 @@ int ADC_Module::analogRead(uint8_t pin) {
 
     // check if we are interrupting a measurement, store setting if so.
     // vars to save the current state of the ADC in case it's in use
-    ADC_Config old_config = {0};
+    ADC_Config old_config = {};
     const uint8_t wasADCInUse = isConverting(); // is the ADC running now?
 
     if(wasADCInUse) { // this means we're interrupting a conversion
@@ -908,7 +908,7 @@ int ADC_Module::analogReadDifferential(uint8_t pinP, uint8_t pinN) {
     uint8_t res = getResolution();
 
     // vars to saved the current state of the ADC in case it's in use
-    ADC_Config old_config = {0};
+    ADC_Config old_config = {};
     uint8_t wasADCInUse = isConverting(); // is the ADC running now?
 
     if(wasADCInUse) { // this means we're interrupting a conversion


### PR DESCRIPTION
allows compilation using -Werror=missing-field-initializers