### PR TITLE
Should be bit wise and (&) not logical And (&&)

### DIFF
--- a/ADC_Module.cpp
+++ b/ADC_Module.cpp
@@ -1519,7 +1519,7 @@ void ADC_Module::startQuadTimer(uint32_t freq) {
         if (interrupts_enabled) {
             // Not sure yet? 
         }
-        if (adc_regs.GC && ADC_GC_DMAEN) {
+        if (adc_regs.GC & ADC_GC_DMAEN) {
             IMXRT_ADC_ETC.DMA_CTRL |= ADC_ETC_DMA_CTRL_TRIQ_ENABLE(ADC_ETC_TRIGGER_INDEX);
         }
     } else {
@@ -1532,7 +1532,7 @@ void ADC_Module::startQuadTimer(uint32_t freq) {
           ADC_ETC_TRIG_CHAIN_IE0(1) /*| ADC_ETC_TRIG_CHAIN_B2B0 */
           | ADC_ETC_TRIG_CHAIN_HWTS0(1) | ADC_ETC_TRIG_CHAIN_CSEL0(adc_pin_channel) ;
 
-        if (adc_regs.GC && ADC_GC_DMAEN) {
+        if (adc_regs.GC & ADC_GC_DMAEN) {
             IMXRT_ADC_ETC.DMA_CTRL |= ADC_ETC_DMA_CTRL_TRIQ_ENABLE(ADC_ETC_TRIGGER_INDEX);
         }
     }

--- a/examples/adc_dma/adc_dma.ino
+++ b/examples/adc_dma/adc_dma.ino
@@ -60,8 +60,8 @@ void setup() {
     // reference can be ADC_REFERENCE::REF_3V3, ADC_REFERENCE::REF_1V2 (not for Teensy LC) or ADC_REF_EXT.
     //adc->setReference(ADC_REFERENCE::REF_1V2, ADC_0); // change all 3.3 to 1.2 if you change the reference to 1V2
 
-    adc->setAveraging(8); // set number of averages
-    adc->setResolution(12); // set bits of resolution
+    adc->adc0->setAveraging(8); // set number of averages
+    adc->adc0->setResolution(12); // set bits of resolution
 
 
     // always call the compare functions after changing the resolution!
@@ -78,8 +78,8 @@ void setup() {
     abdma1.userData(initial_average_value); // save away initial starting average
 #ifdef ADC_DUAL_ADCS
     Serial.println("Setup ADC_1");
-    adc->setAveraging(8, ADC_1); // set number of averages
-    adc->setResolution(12, ADC_1); // set bits of resolution
+    adc->adc1->setAveraging(8); // set number of averages
+    adc->adc1->setResolution(12); // set bits of resolution
     abdma2.init(adc, ADC_1);
     abdma2.userData(initial_average_value); // save away initial starting average
     adc->adc1->startContinuous(readPin_adc_1);


### PR DESCRIPTION
Frank B's compiler caught these...  Some reason when I built earlier these did not show up...

There were two lines like:
```
if (adc_regs.GC && ADC_GC_DMAEN) {
```

That should be:
```
if (adc_regs.GC & ADC_GC_DMAEN) {
```