### PR TITLE
Add the deprecated adc->methods with a [[deprecated]] attribute

### DIFF
--- a/ADC.h
+++ b/ADC.h
@@ -104,6 +104,231 @@ class ADC
         #endif
 
 
+        /////////////// METHODS TO SET/GET SETTINGS OF THE ADC ////////////////////
+
+        //! Set the voltage reference you prefer, default is vcc
+        /*! It recalibrates at the end.
+        *   \param type can be ADC_REFERENCE::REF_3V3, ADC_REFERENCE::REF_1V2 (not for Teensy LC) or ADC_REFERENCE::REF_EXT
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->setReference instead")]]
+        void setReference(ADC_REFERENCE type, int8_t adc_num = -1);
+
+
+        //! Change the resolution of the measurement.
+        /*!
+        *  \param bits is the number of bits of resolution.
+        *  For single-ended measurements: 8, 10, 12 or 16 bits.
+        *  For differential measurements: 9, 11, 13 or 16 bits.
+        *  If you want something in between (11 bits single-ended for example) select the immediate higher
+        *  and shift the result one to the right.
+        *  Whenever you change the resolution, change also the comparison values (if you use them).
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->setResolution instead")]]
+        void setResolution(uint8_t bits, int8_t adc_num = -1);
+
+        //! Returns the resolution of the ADC_Module.
+        /**
+        *   \param adc_num ADC number to query.
+        *   \return the resolution of adc_num ADC.
+        */
+       [[deprecated("Use adc->adcX->getResolution instead")]]
+        uint8_t getResolution(int8_t adc_num = -1);
+
+        //! Returns the maximum value for a measurement: 2^res-1.
+        /**
+        *   \param adc_num ADC number to query.
+        *   \return the maximum value of adc_num ADC.
+        */
+       [[deprecated("Use adc->adcX->getMaxValue instead")]]
+        uint32_t getMaxValue(int8_t adc_num = -1);
+
+
+        //! Sets the conversion speed (changes the ADC clock, ADCK)
+        /**
+        * \param speed can be any from the ADC_CONVERSION_SPEED enum: VERY_LOW_SPEED, LOW_SPEED, MED_SPEED, HIGH_SPEED_16BITS, HIGH_SPEED, VERY_HIGH_SPEED,
+        *       ADACK_2_4, ADACK_4_0, ADACK_5_2 or ADACK_6_2.
+        *
+        * VERY_LOW_SPEED is guaranteed to be the lowest possible speed within specs for resolutions less than 16 bits (higher than 1 MHz),
+        * it's different from LOW_SPEED only for 24, 4 or 2 MHz bus frequency.
+        * LOW_SPEED is guaranteed to be the lowest possible speed within specs for all resolutions (higher than 2 MHz).
+        * MED_SPEED is always >= LOW_SPEED and <= HIGH_SPEED.
+        * HIGH_SPEED_16BITS is guaranteed to be the highest possible speed within specs for all resolutions (lower or eq than 12 MHz).
+        * HIGH_SPEED is guaranteed to be the highest possible speed within specs for resolutions less than 16 bits (lower or eq than 18 MHz).
+        * VERY_HIGH_SPEED may be out of specs, it's different from HIGH_SPEED only for 48, 40 or 24 MHz bus frequency.
+        *
+        * Additionally the conversion speed can also be ADACK_2_4, ADACK_4_0, ADACK_5_2 and ADACK_6_2,
+        * where the numbers are the frequency of the ADC clock (ADCK) in MHz and are independent on the bus speed.
+        * This is useful if you are using the Teensy at a very low clock frequency but want faster conversions,
+        * but if F_BUS<F_ADCK, you can't use VERY_HIGH_SPEED for sampling speed.
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->setConversionSpeed instead")]]
+        void setConversionSpeed(ADC_CONVERSION_SPEED speed, int8_t adc_num = -1);
+
+
+        //! Sets the sampling speed
+        /** Increase the sampling speed for low impedance sources, decrease it for higher impedance ones.
+        * \param speed can be any of the ADC_SAMPLING_SPEED enum: VERY_LOW_SPEED, LOW_SPEED, MED_SPEED, HIGH_SPEED or VERY_HIGH_SPEED.
+        *
+        * VERY_LOW_SPEED is the lowest possible sampling speed (+24 ADCK).
+        * LOW_SPEED adds +16 ADCK.
+        * MED_SPEED adds +10 ADCK.
+        * HIGH_SPEED adds +6 ADCK.
+        * VERY_HIGH_SPEED is the highest possible sampling speed (0 ADCK added).
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->setSamplingSpeed instead")]]
+        void setSamplingSpeed(ADC_SAMPLING_SPEED speed, int8_t adc_num = -1);
+
+
+        //! Set the number of averages
+        /*!
+        * \param num can be 0, 4, 8, 16 or 32.
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->setAveraging instead")]]
+        void setAveraging(uint8_t num, int8_t adc_num = -1);
+
+
+        //! Enable interrupts
+        /** An IRQ_ADCx Interrupt will be raised when the conversion is completed
+        *  (including hardware averages and if the comparison (if any) is true).
+        *   \param adc_num ADC number to change.
+        *   \param isr function (returns void and accepts no arguments) that will be executed after an interrupt.
+        *   \param priority Interrupt priority, highest is 0, lowest is 255.
+        */
+       [[deprecated("Use adc->adcX->enableInterrupts instead")]]
+        void enableInterrupts(void (*isr)(void), uint8_t priority=255, int8_t adc_num = -1);
+
+        //! Disable interrupts
+        /**
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->disableInterrupts instead")]]
+        void disableInterrupts(int8_t adc_num = -1);
+
+
+        #ifdef ADC_USE_DMA
+        //! Enable DMA request
+        /** An ADC DMA request will be raised when the conversion is completed
+        *  (including hardware averages and if the comparison (if any) is true).
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->enableDMA instead")]]
+        void enableDMA(int8_t adc_num = -1);
+
+        //! Disable ADC DMA request
+        /**
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->disableDMA instead")]]
+        void disableDMA(int8_t adc_num = -1);
+        #endif
+
+
+        //! Enable the compare function to a single value
+        /** A conversion will be completed only when the ADC value
+        *  is >= compValue (greaterThan=1) or < compValue (greaterThan=0)
+        *  Call it after changing the resolution
+        *  Use with interrupts or poll conversion completion with isComplete()
+        *   \param compValue value to compare
+        *   \param greaterThan true or false
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->enableCompare instead")]]
+        void enableCompare(int16_t compValue, bool greaterThan, int8_t adc_num = -1);
+
+        //! Enable the compare function to a range
+        /** A conversion will be completed only when the ADC value is inside (insideRange=1) or outside (=0)
+        *  the range given by (lowerLimit, upperLimit),including (inclusive=1) the limits or not (inclusive=0).
+        *  See Table 31-78, p. 617 of the freescale manual.
+        *  Call it after changing the resolution
+        *  Use with interrupts or poll conversion completion with isComplete()
+        *   \param lowerLimit lower value to compare
+        *   \param upperLimit upper value to compare
+        *   \param insideRange true or false
+        *   \param inclusive true or false
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->enableCompareRange instead")]]
+        void enableCompareRange(int16_t lowerLimit, int16_t upperLimit, bool insideRange, bool inclusive, int8_t adc_num = -1);
+
+        //! Disable the compare function
+        /**
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->disableCompare instead")]]
+        void disableCompare(int8_t adc_num = -1);
+
+
+        #ifdef ADC_USE_PGA
+        //! Enable and set PGA
+        /** Enables the PGA and sets the gain
+        *   Use only for signals lower than 1.2 V and only in differential mode
+        *   \param gain can be 1, 2, 4, 8, 16, 32 or 64
+        *   \param adc_num ADC number to change.
+        */
+       [[deprecated("Use adc->adcX->enablePGA instead")]]
+        void enablePGA(uint8_t gain, int8_t adc_num = -1);
+
+        //! Returns the PGA level
+        /** PGA level = from 1 to 64
+        *   \param adc_num ADC number to query.
+        *   \return PGA level = from 1 to 64
+        */
+       [[deprecated("Use adc->adcX->getPGA instead")]]
+        uint8_t getPGA(int8_t adc_num = -1);
+
+        //! Disable PGA
+        /**
+        *   \param adc_num ADC number to query
+        */
+       [[deprecated("Use adc->adcX->disablePGA instead")]]
+        void disablePGA(int8_t adc_num = -1);
+        #endif
+
+
+
+        ////////////// INFORMATION ABOUT THE STATE OF THE ADC /////////////////
+
+        //! Is the ADC converting at the moment?
+        /**
+        *   \param adc_num ADC number to query
+        *   \return true if yes, false if not.
+        */
+       [[deprecated("Use adc->adcX->isConverting instead")]]
+        bool isConverting(int8_t adc_num = -1);
+
+        //! Is an ADC conversion ready?
+        /** When a value is read this function returns 0 until a new value exists
+        *   So it only makes sense to call it with continuous or non-blocking methods
+        *   \param adc_num ADC number to query
+        *   \return true if yes, false if not.
+        */
+       [[deprecated("Use adc->adcX->isComplete instead")]]
+        bool isComplete(int8_t adc_num = -1);
+
+        #if ADC_DIFF_PAIRS > 0
+        //! Is the ADC in differential mode?
+        /**
+        *   \param adc_num ADC number to query
+        *   \return true or false
+        */
+       [[deprecated("Use adc->adcX->isDifferential instead")]]
+        bool isDifferential(int8_t adc_num = -1);
+        #endif
+
+        //! Is the ADC in continuous mode?
+        /**
+        *   \param adc_num ADC number to query
+        *   \return true or false
+        */
+       [[deprecated("Use adc->adcX->isContinuous instead")]]
+        bool isContinuous(int8_t adc_num = -1);
+
+
         //////////////// BLOCKING CONVERSION METHODS //////////////////
 
         //! Returns the analog value of the pin.


### PR DESCRIPTION
The adc->methods removed in #49 are added back (only their definitions) with a deprecated attribute so people know why they are missing and pointed them to the adc->adcX->method