### PR TITLE
AnalogBufferDMA.cpp: Fix TeensyLC adc_test compile

### DIFF
--- a/AnalogBufferDMA.cpp
+++ b/AnalogBufferDMA.cpp
@@ -172,7 +172,7 @@ void AnalogBufferDMA::init(ADC *adc, int8_t adc_num)
   _dmachannel_adc.enable();
 
   adc->startContinuous(adc_num);
-  adc->enableDMA(adc_num);
+  adc->adc[adc_num]->enableDMA();
 #ifdef DEBUG_DUMP_DATA
   dumpDMA_TCD(&_dmachannel_adc);
 #endif


### PR DESCRIPTION
As is, the examples/adc_test errors on this line with an error like this:


    /Users/drf/Documents/Arduino/libraries/ADC/AnalogBufferDMA.cpp: In member function 'void AnalogBufferDMA::init(ADC*, int8_t)':
    /Users/drf/Documents/Arduino/libraries/ADC/AnalogBufferDMA.cpp:175:26: error: call to 'ADC::enableDMA' declared with attribute error: Use adc->adcX->enableDMA instead
    adc->enableDMA(adc_num);
                          ^
     Multiple libraries were found for "ADC.h"
     Used: /Users/drf/Documents/Arduino/libraries/ADC  
     Not used: /private/var/folders/7g/2b2t5vv15cg3yrp46fm2yv7h0000gt/T/AppTranslocation/22F939BB-65F5-4970-8746-976D57711154/d/Teensyduino.app/Contents/Java/hardware/teensy/avr/libraries/ADC
    Error compiling for board Teensy LC.

Changing the line to:

    adc->adc[adc_num]->enableDMA();

makes it compile as expected.
